### PR TITLE
[4] Fix Edit Sailor Mutation Bug

### DIFF
--- a/src/components/TheAppBarComponent.vue
+++ b/src/components/TheAppBarComponent.vue
@@ -13,7 +13,7 @@
       <v-btn text
              tile
              color="white"
-             @click.stop="showAddSailorDialog = !showAddSailorDialog">
+             @click.stop="showAddEditSailorDialog()">
         Add Sailor
       </v-btn>
       <v-btn icon
@@ -62,5 +62,12 @@ export default Vue.extend({
       },
     },
   },
+  methods: {
+    showAddEditSailorDialog() {
+      this.$store.dispatch("clearSailorEditForm").then(() => {
+        this.showAddSailorDialog = !this.showAddSailorDialog;
+      });
+    }
+  }
 });
 </script>

--- a/src/components/TheSailorDetailComponent.vue
+++ b/src/components/TheSailorDetailComponent.vue
@@ -7,7 +7,7 @@
         <v-btn icon
                small
                color="primary"
-               @click="showEditSailorDialog(sailor.uuid)">
+               @click="showEditSailorDialog()">
           <v-icon small>
             mdi-pencil
           </v-icon>
@@ -102,7 +102,7 @@
     </v-expansion-panels>
     <TheAddEvalDialogComponent v-model="showAddEvalDialog" />
     <TheAddEditSailorDialogComponent v-model="showAddSailorDialog"
-                                     :edit="true" />
+                                     :sailor="sailor" />
   </v-card>
 </template>
 
@@ -141,9 +141,8 @@ export default Vue.extend({
     }
   },
   methods: {
-    showEditSailorDialog(givenUuid) {
-      this.$store.dispatch("setSelectedSailor", givenUuid).then(() => {
-        this.$store.dispatch("setSailorEditForm", givenUuid);
+    showEditSailorDialog() {
+      this.$store.dispatch("setSailorEditForm", this.sailor).then(() => {
         this.showAddSailorDialog = !this.showAddSailorDialog;
       });
     },

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -9,8 +9,9 @@ export default {
       commit("SET_SAILORS", response.sailors);
     });
   },
-  addSailor({ commit, dispatch }, payload) {
-    db.addSailor(payload).then(response => {
+  addSailor({ commit, dispatch }) {
+    const form = this.getters.getSailorEditForm;
+    db.addSailor(form).then(response => {
       if (response.error) {
         commit("setError");
         commit("setErrorMsg", response.error?.toString());
@@ -21,8 +22,9 @@ export default {
       });
     });
   },
-  updateSailor({ commit, dispatch }, payload) {
-    db.updateSailor(payload).then(response => {
+  updateSailor({ commit, dispatch }) {
+    const form = this.getters.getSailorEditForm;
+    db.updateSailor(form).then(response => {
       if (response.error) {
         commit("setError");
         commit("setErrorMsg", response.error?.toString());
@@ -54,9 +56,15 @@ export default {
   setSelectedSailor({ commit }, uuid) {
     const sailorData = this.getters.getSailorById(uuid);
     commit("SET_SELECTED_SAILOR", sailorData);
+    commit("SET_SAILOR_EDIT_FORM", sailorData);
   },
-  setSailorEditForm({ commit }, uuid) {
-    commit("SET_SELECTED_SAILOR", this.getters.getSailorById(uuid));
-    // commit("SET_SAILOR_EDIT_FORM", );
+  setSailorEditForm({ commit }, payload) {
+    commit("SET_SAILOR_EDIT_FORM", payload);
   },
+  updateSailorEditForm({ commit }, payload) {
+    commit("UPDATE_SAILOR_EDIT_FORM", payload);
+  },
+  clearSailorEditForm({ commit }) {
+    commit("CLEAR_SAILOR_EDIT_FORM");
+  }
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,6 +20,7 @@ export default new Vuex.Store({
   actions,
   getters: {
     isError: state => state.app.isError,
+    errorMsg: state => state.app.errorMsg,
     memberStatuses: state => state.defaults.memberStatuses,
     promotionStatuses: state => state.defaults.promotionStatuses,
     ranksAll: state => state.defaults.ranks,

--- a/src/store/modules/forms.js
+++ b/src/store/modules/forms.js
@@ -6,6 +6,12 @@ export default {
     SET_SAILOR_EDIT_FORM(state, payload) {
       state.sailorEdit = payload;
     },
+    UPDATE_SAILOR_EDIT_FORM(state, payload) {
+      state.sailorEdit[payload.input] = payload.value;
+    },
+    CLEAR_SAILOR_EDIT_FORM(state) {
+      state.sailorEdit = {};
+    }
   },
   getters: {
     getSailorEditForm: state => state.sailorEdit,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4651,7 +4651,7 @@ eslint-config-airbnb-base@^14.0.0:
     object.assign "^4.1.0"
     object.entries "^1.1.2"
 
-eslint-import-resolver-node@^0.3.3, eslint-import-resolver-node@^0.3.4:
+eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
   integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -4702,16 +4702,16 @@ eslint-plugin-cypress@^2.10.3:
     globals "^11.12.0"
 
 eslint-plugin-import@^2.21.2:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
-  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flat "^1.2.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.3"
+    eslint-import-resolver-node "^0.3.4"
     eslint-module-utils "^2.6.0"
     has "^1.0.3"
     minimatch "^3.0.4"


### PR DESCRIPTION
Closes #4 

The current implementation using `v-model` ties directly to state bypassing actions, etc and is not in line with the vuex rules which causes the state to be modified on input change.

I've modified the dialog to accept a sailor object on editing or defaults to empty form strings, etc and it updates the store state under the `sailorEdit: {}` object.

Upon submission the store add/or update sailor actions will utilize the `sailorEdit` state to save to the DB.