### PR TITLE
Change fillForm function to allow for non-flattening

### DIFF
--- a/src/services/evalExport.service.js
+++ b/src/services/evalExport.service.js
@@ -27,7 +27,7 @@ export function exportEval({ sailor, recordId }) {
 
   const record = buildEval(sailor, selectedRecord);
 
-  pdfFiller.fillForm(sourcePDF, pdfName, record, shouldFlatten, err => {
+  pdfFiller.fillFormWithFlatten(sourcePDF, pdfName, record, shouldFlatten, err => {
     if (err) throw err;
     console.log("In callback (we're done).");
   });


### PR DESCRIPTION
Current implementation removes the ability to continue editing the PDF.

Change the function from `fillForm` to `fillFormWithFlatten` so the `shouldFlatten` param is accepted.